### PR TITLE
Support Unicode

### DIFF
--- a/ckanext/__init__.py
+++ b/ckanext/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # this is a namespace package
 try:
     import pkg_resources

--- a/ckanext/pages/__init__.py
+++ b/ckanext/pages/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # this is a namespace package
 try:
     import pkg_resources

--- a/ckanext/pages/actions.py
+++ b/ckanext/pages/actions.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 import json
 

--- a/ckanext/pages/auth.py
+++ b/ckanext/pages/auth.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as p
 
 try:

--- a/ckanext/pages/controller.py
+++ b/ckanext/pages/controller.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as p
 import ckan.lib.helpers as helpers
 from pylons import config

--- a/ckanext/pages/db.py
+++ b/ckanext/pages/db.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 import uuid
 import json

--- a/ckanext/pages/plugin.py
+++ b/ckanext/pages/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 from pylons import config
 import ckan.plugins.toolkit as toolkit
@@ -48,9 +50,9 @@ def build_pages_nav_main(*args):
 
     for page in pages_list:
         if page['page_type'] == 'blog':
-            link = h.literal('<a href="/blog/%s">%s</a>' % (str(page['name']), str(page['title'])))
+            link = h.literal('<a href="/blog/%s">%s</a>' % (page['name'], page['title']))
         else:
-            link = h.literal('<a href="/pages/%s">%s</a>' % (str(page['name']), str(page['title'])))
+            link = h.literal('<a href="/pages/%s">%s</a>' % (page['name'], page['title']))
 
         if page['name'] == page_name:
             li = h.literal('<li class="active">') + link + h.literal('</li>')

--- a/ckanext/pages/tests/test_logic.py
+++ b/ckanext/pages/tests/test_logic.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.plugins import toolkit
 from nose.tools import assert_in, assert_not_in
 import ckan.model as model

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from setuptools import setup, find_packages
 import os
 


### PR DESCRIPTION
Explicitly declare UTF-8 encoding, like CKAN core, and remove conversions of page title and name to `str`, which 1) aren't necessary and 2) will fail if there are Unicode characters in either field.