### PR TITLE
Fixed setup.py for wheel compiling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,34 +52,12 @@ setup(
     namespace_packages=['ckanext'],
     include_package_data=True,
     package_data={
-            '': ['theme/*/*.html', 'theme/*/*/*.html', 'theme/*/*/*/*.html'],
+            '': ['theme/*/*.html', 'theme/*/*/*.html', 'theme/*/*/*/*.html'] + i18n_files,
     },
     zip_safe=False,
     install_requires=[
         # -*- Extra requirements: -*-
     ],
-    entry_points=\
-    """
-	name='ckanext-pages',
-	version=version,
-	description='Basic CMS extension for ckan',
-	long_description='',
-	classifiers=[], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-	keywords='',
-	author='David Raznick',
-	author_email='david.raznick@gokfn.org',
-	url='',
-	license='',
-	packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-	namespace_packages=['ckanext'],
-	include_package_data=True,
-	package_data={
-            '': ['theme/*/*.html', 'theme/*/*/*.html', 'theme/*/*/*/*.html'] + i18n_files,
-	},
-	zip_safe=False,
-	install_requires=[
-		# -*- Extra requirements: -*-
-	],
 	entry_points=\
 	"""
         [ckan.plugins]


### PR DESCRIPTION
The setup config was throwing out an error and the python wheel could not compile because of it. The issue was in the `setup.py` file which had a bad multiline string which was confusing the wheel builder.